### PR TITLE
Don't actually deploy lambda-boilerplate to prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,8 +1,8 @@
 name: Deploy Prod
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Comment out the prod deployment action on `push`, since we don't actually want to deploy lambda-boilerplate to prod, but we still want to keep the action configuration as a template for new projects based on lambda-boilerplate.